### PR TITLE
IE10/11 Browser User Agent Fix

### DIFF
--- a/vendor/assets/javascripts/spoiler.js
+++ b/vendor/assets/javascripts/spoiler.js
@@ -4,7 +4,7 @@
     browser.mozilla = /mozilla/.test(userAgent) && !/webkit/.test(userAgent);
     browser.webkit = /webkit/.test(userAgent);
     browser.opera = /opera/.test(userAgent);
-    browser.msie = /msie/.test(userAgent);
+    browser.msie = /msie/.test(userAgent) || /trident/.test(userAgent);
 
     var defaults = {
         max: 4,


### PR DESCRIPTION
The function that determines what browser the user is currently using
can lead to several issues with the most recent (and future versions)
of Internet Explorer. Due to some "trickery" done by Microsoft, the
most recent versions of IE no longer include the MSIE tag which
previously determined their browsers.

For more information, please read the following:
http://blogs.msdn.com/b/ieinternals/archive/2013/09/21/internet-explorer-11-user-agent-string-ua-string-sniffing-compatibility-with-gecko-webkit.aspx

https://msdn.microsoft.com/en-us/library/ie/bg182625(v=vs.85).aspx#uaString
